### PR TITLE
Update to neubot-server v0.6.0.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "neubot"]
-	path = neubot
-	url = https://github.com/neubot/neubot.git
 [submodule "package"]
 	path = package
 	url = https://github.com/m-lab/package.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "package"]
 	path = package
 	url = https://github.com/m-lab/package.git
+[submodule "neubot-server"]
+	path = neubot-server
+	url = https://github.com/neubot/neubot-server

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ neubot.mlab.mlab4.prg01.measurement-lab.org), then:
 ### Install development tools
 
 ```
-yum --disablerepo=epel groupinstall -y 'Development tools'
+sudo yum --disablerepo=epel groupinstall -y 'Development tools'
 ```
 
 ### Clone the repository

--- a/README.md
+++ b/README.md
@@ -17,25 +17,28 @@ yum --disablerepo=epel groupinstall -y 'Development tools'
 
 ```
 cd /tmp
+rm -rf mlab-neubot-support
 git clone --recursive -b develop https://github.com/neubot/mlab-neubot-support.git
 ```
 
 ### Run the slicebuild.sh script
 
 ```
-cd neubot-support
+cd mlab-neubot-support
+git tag
+git checkout $tag # very important to make the RPM package
 ./package/slicebuild.sh mlab_neubot
-find . -type f -name \*.rpm
+find /tmp -type f -name \*.rpm
 # scp the generated rpm from that sliver to your machine
 ```
 
 ### Test the new RPM
 
-You need to scp the RPM to another testing sliver (e.g. a good sliver for
-that could be neubot.mlab.mlab1.nuq0t.measurement-lab.org).
+You can use the `deploy.sh` script to test the RPM to another testing sliver
+(e.g. neubot.mlab.mlab1.nuq0t.measurement-lab.org).
 
-Then, install the rpm
+Run:
 
 ```
-sudo rpm -i $rpm_file_path
+./deploy.sh $rpm neubot.mlab.mlab1.nuq0t.measurement-lab.org
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Support scripts for Neubot on M-Lab.
 
 ## Build RPM from development branch
 
-Login on a development machine (i.e. mlab4.prg01), then:
+Login on a development machine (e.g.
+neubot.mlab.mlab4.prg01.measurement-lab.org), then:
 
 ### Install development tools
 
@@ -16,14 +17,25 @@ yum --disablerepo=epel groupinstall -y 'Development tools'
 
 ```
 cd /tmp
-git clone --recursive -b develop https://github.com/neubot/neubot-support.git
+git clone --recursive -b develop https://github.com/neubot/mlab-neubot-support.git
 ```
 
 ### Run the slicebuild.sh script
 
 ```
 cd neubot-support
-git checkout <tag>
 ./package/slicebuild.sh mlab_neubot
 find . -type f -name \*.rpm
+# scp the generated rpm from that sliver to your machine
+```
+
+### Test the new RPM
+
+You need to scp the RPM to another testing sliver (e.g. a good sliver for
+that could be neubot.mlab.mlab1.nuq0t.measurement-lab.org).
+
+Then, install the rpm
+
+```
+sudo rpm -i $rpm_file_path
 ```

--- a/README.md
+++ b/README.md
@@ -2,19 +2,28 @@
 
 Support scripts for Neubot on M-Lab.
 
-## Install development tools
+## Build RPM from development branch
+
+Login on a development machine (i.e. mlab4.prg01), then:
+
+### Install development tools
 
 ```
 yum --disablerepo=epel groupinstall -y 'Development tools'
 ```
 
-## Build RPM from development branch
+### Clone the repository
 
 ```
 cd /tmp
 git clone --recursive -b develop https://github.com/neubot/neubot-support.git
+```
+
+### Run the slicebuild.sh script
+
+```
 cd neubot-support
 git checkout <tag>
-./package/slicebuild.sh neubot
+./package/slicebuild.sh mlab_neubot
 find . -type f -name \*.rpm
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
-neubot-support
-==============
+# Neubot support for M-Lab
 
-Support scripts for Neubot on M-Lab
+Support scripts for Neubot on M-Lab.
 
-    yum groupinstall -y 'Development tools'  # if not already done
+## Install development tools
 
-    git clone --recursive https://github.com/m-lab-tools/neubot-support.git
-    cd neubot-support
-    git checkout <tag>
-    ./package/slicebuild.sh neubot
+```
+yum --disablerepo=epel groupinstall -y 'Development tools'
+```
+
+## Build RPM from development branch
+
+```
+cd /tmp
+git clone --recursive -b develop https://github.com/neubot/neubot-support.git
+cd neubot-support
+git checkout <tag>
+./package/slicebuild.sh neubot
+find . -type f -name \*.rpm
+```

--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -32,24 +32,24 @@ fi
 
 cd /home/mlab_neubot
 
-if [ -f neubot-server.tar.gz ]; then
+if [ -f neubot.tar.gz ]; then
 
-    if [ -x /home/mlab_neubot/neubot-server/M-Lab/uninstall.sh ]; then
+    if [ -x /home/mlab_neubot/neubot/M-Lab/uninstall.sh ]; then
         echo "uninstall previous neubot"
-        /home/mlab_neubot/neubot-server/M-Lab/uninstall.sh
+        /home/mlab_neubot/neubot/M-Lab/uninstall.sh
     fi
 
     echo "extract new neubot"
-    tar -xzf neubot-server.tar.gz
+    tar -xzf neubot.tar.gz
 
     echo "install new neubot"
-    /home/mlab_neubot/neubot-server/M-Lab/install.sh
+    /home/mlab_neubot/neubot/M-Lab/install.sh
 
     # Note: would be wrong to cleanup because tarball is installed by the RPM
     #echo "cleanup"
-    #rm -rf neubot-server.tar.gz
+    #rm -rf neubot.tar.gz
 
 else
-    echo "FATAL: neubot-server.tar.gz missing" 1>&2
+    echo "FATAL: neubot.tar.gz missing" 1>&2
     exit 1
 fi

--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -34,16 +34,16 @@ cd /home/mlab_neubot
 
 if [ -f neubot.tar.gz ]; then 
 
-    if [ -x /home/mlab_neubot/neubot/M-Lab/uninstall.sh ]; then
+    if [ -x /home/mlab_neubot/neubot-server/M-Lab/uninstall.sh ]; then
         echo "uninstall previous neubot"
-        /home/mlab_neubot/neubot/M-Lab/uninstall.sh
+        /home/mlab_neubot/neubot-server/M-Lab/uninstall.sh
     fi
 
     echo "extract new neubot"
     tar -xzf neubot.tar.gz
 
     echo "install new neubot"
-    /home/mlab_neubot/neubot/M-Lab/install.sh
+    /home/mlab_neubot/neubot-server/M-Lab/install.sh
 
     #echo "cleanup"
     #rm -rf neubot.tar.gz

--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -40,7 +40,7 @@ if [ -f neubot-server.tar.gz ]; then
     fi
 
     echo "extract new neubot"
-    tar -xzf neubot.tar.gz
+    tar -xzf neubot-server.tar.gz
 
     echo "install new neubot"
     /home/mlab_neubot/neubot-server/M-Lab/install.sh
@@ -50,6 +50,6 @@ if [ -f neubot-server.tar.gz ]; then
     #rm -rf neubot-server.tar.gz
 
 else
-    echo "FATAL: neubot.tar.gz missing" 1>&2
+    echo "FATAL: neubot-server.tar.gz missing" 1>&2
     exit 1
 fi

--- a/init/initialize.sh
+++ b/init/initialize.sh
@@ -32,7 +32,7 @@ fi
 
 cd /home/mlab_neubot
 
-if [ -f neubot.tar.gz ]; then 
+if [ -f neubot-server.tar.gz ]; then
 
     if [ -x /home/mlab_neubot/neubot-server/M-Lab/uninstall.sh ]; then
         echo "uninstall previous neubot"
@@ -45,8 +45,9 @@ if [ -f neubot.tar.gz ]; then
     echo "install new neubot"
     /home/mlab_neubot/neubot-server/M-Lab/install.sh
 
+    # Note: would be wrong to cleanup because tarball is installed by the RPM
     #echo "cleanup"
-    #rm -rf neubot.tar.gz
+    #rm -rf neubot-server.tar.gz
 
 else
     echo "FATAL: neubot.tar.gz missing" 1>&2

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -38,6 +38,11 @@ fi
 echo "Source dir: $SOURCE_DIR"
 echo "Build dir: $BUILD_DIR"
 
+if test -d $BUILD_DIR ; then
+    rm -rf $BUILD_DIR/*
+fi
+
+
 #if [ $# -gt 1 ]; then
 #    echo "usage: $0 [branch]" 1>&2
 #    exit 1

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -35,6 +35,9 @@ if [ -z "$BUILD_DIR" ] ; then
     exit 1
 fi
 
+echo "Source dir: $SOURCE_DIR"
+echo "Build dir: $BUILD_DIR"
+
 if test -d $BUILD_DIR ; then
     rm -rf $BUILD_DIR/*
 fi

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -38,11 +38,6 @@ fi
 echo "Source dir: $SOURCE_DIR"
 echo "Build dir: $BUILD_DIR"
 
-if test -d $BUILD_DIR ; then
-    rm -rf $BUILD_DIR/*
-fi
-
-
 #if [ $# -gt 1 ]; then
 #    echo "usage: $0 [branch]" 1>&2
 #    exit 1

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -59,11 +59,11 @@ fi
 umask 022  # Override possibly-stricter user umask
 #echo "NOTICE: preparing release from ${REMOTEBRANCH}'s HEAD"
 
-GITDIR=neubot-server
+GITDIR=neubot
 
 pushd $SOURCE_DIR/$GITDIR
     DESTDIR=dist/mlab
-    TARBALL=$DESTDIR/neubot-server.tar.gz
+    TARBALL=$DESTDIR/neubot.tar.gz
     VERSION=$DESTDIR/version
 
     rm -rf -- $DESTDIR
@@ -71,7 +71,7 @@ pushd $SOURCE_DIR/$GITDIR
     #git fetch origin
     #git checkout $REMOTEBRANCH
     #git reset --hard origin/$REMOTEBRANCH
-    git archive --format=tar --prefix=neubot-server/ HEAD|gzip -9 > $TARBALL
+    git archive --format=tar --prefix=neubot/ HEAD|gzip -9 > $TARBALL
     git describe --tags > $VERSION
 popd
 
@@ -79,7 +79,7 @@ for file in initialize.sh start.sh stop.sh ; do
     install -D -m 0755 $SOURCE_DIR/init/$file $BUILD_DIR/init/$file
 done
 #install $SOURCE_DIR/initialize.sh start.sh stop.sh $BUILD_DIR/init
-cp $SOURCE_DIR/neubot-server/dist/mlab/* $BUILD_DIR
+cp $SOURCE_DIR/neubot/dist/mlab/* $BUILD_DIR
 
 #
 # Use '*' rather than '.' because we don't want to include the current

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -56,11 +56,11 @@ fi
 umask 022  # Override possibly-stricter user umask
 #echo "NOTICE: preparing release from ${REMOTEBRANCH}'s HEAD"
 
-GITDIR=neubot
+GITDIR=neubot-server
 
 pushd $SOURCE_DIR/$GITDIR
     DESTDIR=dist/mlab
-    TARBALL=$DESTDIR/neubot.tar.gz
+    TARBALL=$DESTDIR/neubot-server.tar.gz
     VERSION=$DESTDIR/version
 
     rm -rf -- $DESTDIR
@@ -68,7 +68,7 @@ pushd $SOURCE_DIR/$GITDIR
     #git fetch origin
     #git checkout $REMOTEBRANCH
     #git reset --hard origin/$REMOTEBRANCH
-    git archive --format=tar --prefix=neubot/ HEAD|gzip -9 > $TARBALL
+    git archive --format=tar --prefix=neubot-server/ HEAD|gzip -9 > $TARBALL
     git describe --tags > $VERSION
 popd
 

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -76,7 +76,7 @@ for file in initialize.sh start.sh stop.sh ; do
     install -D -m 0755 $SOURCE_DIR/init/$file $BUILD_DIR/init/$file
 done
 #install $SOURCE_DIR/initialize.sh start.sh stop.sh $BUILD_DIR/init
-cp $SOURCE_DIR/neubot/dist/mlab/* $BUILD_DIR
+cp $SOURCE_DIR/neubot-server/dist/mlab/* $BUILD_DIR
 
 #
 # Use '*' rather than '.' because we don't want to include the current

--- a/init/prepare.sh
+++ b/init/prepare.sh
@@ -59,7 +59,7 @@ fi
 umask 022  # Override possibly-stricter user umask
 #echo "NOTICE: preparing release from ${REMOTEBRANCH}'s HEAD"
 
-GITDIR=neubot
+GITDIR=neubot-server
 
 pushd $SOURCE_DIR/$GITDIR
     DESTDIR=dist/mlab
@@ -79,7 +79,7 @@ for file in initialize.sh start.sh stop.sh ; do
     install -D -m 0755 $SOURCE_DIR/init/$file $BUILD_DIR/init/$file
 done
 #install $SOURCE_DIR/initialize.sh start.sh stop.sh $BUILD_DIR/init
-cp $SOURCE_DIR/neubot/dist/mlab/* $BUILD_DIR
+cp $SOURCE_DIR/$GITDIR/dist/mlab/* $BUILD_DIR
 
 #
 # Use '*' rather than '.' because we don't want to include the current

--- a/init/start.sh
+++ b/init/start.sh
@@ -29,5 +29,5 @@
 #
 
 DEBUG=
-$DEBUG /home/mlab_neubot/neubot/M-Lab/start.sh
-$DEBUG /home/mlab_neubot/neubot/M-Lab/check.sh
+$DEBUG /home/mlab_neubot/neubot-server/M-Lab/start.sh
+$DEBUG /home/mlab_neubot/neubot-server/M-Lab/check.sh

--- a/init/start.sh
+++ b/init/start.sh
@@ -29,5 +29,5 @@
 #
 
 DEBUG=
-$DEBUG /home/mlab_neubot/neubot-server/M-Lab/start.sh
-$DEBUG /home/mlab_neubot/neubot-server/M-Lab/check.sh
+$DEBUG /home/mlab_neubot/neubot/M-Lab/start.sh
+$DEBUG /home/mlab_neubot/neubot/M-Lab/check.sh

--- a/init/stop.sh
+++ b/init/stop.sh
@@ -29,4 +29,4 @@
 #
 
 DEBUG=
-$DEBUG /home/mlab_neubot/neubot/M-Lab/stop.sh
+$DEBUG /home/mlab_neubot/neubot-server/M-Lab/stop.sh

--- a/init/stop.sh
+++ b/init/stop.sh
@@ -29,4 +29,4 @@
 #
 
 DEBUG=
-$DEBUG /home/mlab_neubot/neubot-server/M-Lab/stop.sh
+$DEBUG /home/mlab_neubot/neubot/M-Lab/stop.sh


### PR DESCRIPTION
This pull request updates the repository to use neubot-server v0.6.0.4. Compared to v0.4.16.9 (the version currently installed on mlab), this is what has been changed:

1. moved neubot server-side code [to a specific repository](https://github.com/neubot/neubot-server)

2. remove experimental code that was not actually used (e.g. code for ssl sockets)

3. add support for the [botticelli](https://github.com/neubot/botticelli) NDT multi stream server

4. update to a more recent version of [mlab's package repository](https://github.com/m-lab/package)

I have tested this on testing machines for some days.

Thank you!